### PR TITLE
fix: change OpenPosition struct to avoid errors for `docalcs` equal to False

### DIFF
--- a/src/response_types.rs
+++ b/src/response_types.rs
@@ -812,8 +812,8 @@ pub struct OpenPosition {
     #[serde(rename(deserialize = "vol_closed"))]
     pub volume_closed: Decimal,
     pub margin: Decimal,
-    pub value: Decimal,
-    pub net: Decimal,
+    pub value: Option<Decimal>,
+    pub net: Option<Decimal>,
     pub terms: String,
     #[serde(rename = "rollovertm")]
     pub rollover_time: String,

--- a/tests/resources/kraken_responses/account_response_json.rs
+++ b/tests/resources/kraken_responses/account_response_json.rs
@@ -667,6 +667,30 @@ pub fn get_open_positions_json() -> Value {
         }
     })
 }
+pub fn get_open_positions_json_do_calc_optional_fields() -> Value {
+    json!({
+        "error": [ ],
+        "result": {
+            "TF5GVO-T7ZZ2-6NBKBI": {
+                "ordertxid": "OLWNFG-LLH4R-D6SFFP",
+                "posstatus": "open",
+                "pair": "XXBTZUSD",
+                "time": 1605280097.8294,
+                "type": "buy",
+                "ordertype": "limit",
+                "cost": "104610.52842",
+                "fee": "289.06565",
+                "vol": "8.82412861",
+                "vol_closed": "0.20200000",
+                "margin": "20922.10568",
+                "terms": "0.0100% per 4 hours",
+                "rollovertm": "1616672637",
+                "misc": "",
+                "oflags": ""
+            }
+        }
+    })
+}
 
 pub fn get_ledgers_info_json() -> Value {
     json!({


### PR DESCRIPTION
I'm not sure if you're open to contributions but I came across (what I think is) a bug. 

When making a Rest API call to the OpenPositions endpoint if `docalcs` is set to false then an error is thrown because the fields `value` and `net` are not returned so Serde returns an error. This can be fixed by making those two fields optional so that the request works both if `docalcs` is true or false

For reference the docs [here](https://docs.kraken.com/rest/#tag/Account-Data/operation/getOpenPositions) indicate that `value` and `net` are not returned if `docalcs` is set to false