### PR TITLE
fix: ExecutionResult with triggers

### DIFF
--- a/src/wss/v2/user_data_messages.rs
+++ b/src/wss/v2/user_data_messages.rs
@@ -203,11 +203,11 @@ pub struct TriggerDescription {
     pub reference: TriggerType,
     pub price: Decimal,
     pub price_type: PriceType,
-    pub actual_price: Decimal,
-    pub peak_price: Decimal,
-    pub last_price: Decimal,
+    pub actual_price: Option<Decimal>,
+    pub peak_price: Option<Decimal>,
+    pub last_price: Option<Decimal>,
     pub status: TriggerStatus,
-    pub timestamp: String,
+    pub timestamp: Option<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]


### PR DESCRIPTION
Hi, I've just run across your project and loving it :)

I noticed a few edge cases where `ExecutionResult` with triggers (stop-loss, take-profit, etc.) would cause `Serde data did not match any variant of untagged enum` error, and it turns out that some of the `TriggerDescription` fields should be optional.

I've added the fix and an additional test to cover it. Please feel free to let me know what you think. Thanks!