### PR TITLE
Update TradeType Enum With New Variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Add "stop market", "touched market" and "liquidation market" to `TradeType`
     - If you've matched on this enum exhaustively, these cases will need to be added. Otherwise, this is non-breaking.
+- Add `timestamp` field to `L3Orderbook` and `L3OrderbookUpdate`
+    - If you've instantiated these directly, struct definitions will require the new fields
 
 ### v0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - Considering package re-organization for better imports etc.
 - Convenient type defs and functions for verbose type signatures like `Box<Arc<Mutex<dyn SecretsProvider>>>`
 
+### v0.11.0
+
+**All changes are breaking unless otherwise noted and given upgrade instructions.**
+
+- Add "stop market", "touched market" and "liquidation market" to `TradeType`
+    - If you've matched on this enum exhaustively, these cases will need to be added. Otherwise, this is non-breaking.
+
 ### v0.10.0
 
 **All changes are breaking unless otherwise noted and given upgrade instructions.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "kraken-async-rs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-rate-limit",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kraken-async-rs"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Brendan Blanchard"]
 description = "An async REST and WSS client for the Kraken Pro APIs"

--- a/examples/live_wss_l3.rs
+++ b/examples/live_wss_l3.rs
@@ -1,0 +1,52 @@
+use kraken_async_rs::clients::core_kraken_client::CoreKrakenClient;
+use kraken_async_rs::clients::kraken_client::KrakenClient;
+use kraken_async_rs::crypto::nonce_provider::{IncreasingNonceProvider, NonceProvider};
+use kraken_async_rs::secrets::secrets_provider::{EnvSecretsProvider, SecretsProvider};
+use kraken_async_rs::test_support::set_up_logging;
+use kraken_async_rs::wss::KrakenWSSClient;
+use kraken_async_rs::wss::{BookSubscription, Message, WssMessage};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+use tokio_stream::StreamExt;
+use tracing::{info, warn};
+
+/// Subscribe to websockets for L3 orderbooks, which requires authentication with a token.
+#[tokio::main]
+async fn main() {
+    set_up_logging("ws_live_l3.log");
+
+    let mut client = KrakenWSSClient::new();
+    let mut kraken_stream = client.connect_auth::<WssMessage>().await.unwrap();
+
+    let secrets_provider: Box<Arc<Mutex<dyn SecretsProvider>>> = Box::new(Arc::new(Mutex::new(
+        EnvSecretsProvider::new("KRAKEN_KEY", "KRAKEN_SECRET"),
+    )));
+    let nonce_provider: Box<Arc<Mutex<dyn NonceProvider>>> =
+        Box::new(Arc::new(Mutex::new(IncreasingNonceProvider::new())));
+    let mut kraken_client = CoreKrakenClient::new(secrets_provider, nonce_provider);
+
+    let token = kraken_client
+        .get_websockets_token()
+        .await
+        .unwrap()
+        .result
+        .unwrap()
+        .token;
+
+    let mut book_params = BookSubscription::new_l3(vec!["BTC/USD".into()], token);
+    book_params.snapshot = Some(true);
+    let subscription = Message::new_subscription(book_params, 0);
+
+    let result = kraken_stream.send(&subscription).await;
+    assert!(result.is_ok());
+
+    while let Ok(Some(message)) = timeout(Duration::from_secs(10), kraken_stream.next()).await {
+        if let Ok(response) = message {
+            info!("{:?}", response);
+        } else {
+            warn!("Message failed: {:?}", message);
+        }
+    }
+}

--- a/src/response_types.rs
+++ b/src/response_types.rs
@@ -179,6 +179,12 @@ pub enum TradeType {
     TakeProfitLimit,
     #[serde(rename = "settle position")]
     SettlePosition,
+    #[serde(rename = "stop market")]
+    StopMarket,
+    #[serde(rename = "touched market")]
+    TouchedMarket,
+    #[serde(rename = "liquidation market")]
+    LiquidationMarket,
 }
 
 impl Display for OrderType {

--- a/src/wss/kraken_wss_client.rs
+++ b/src/wss/kraken_wss_client.rs
@@ -688,7 +688,8 @@ mod tests {
             {"order_id":"OUPTOY-CCUJG-BMAZ5S","limit_price":66579.3,"order_qty":0.07800000,"timestamp":"2024-05-19T18:55:22.531833732Z"},
             {"order_id":"OFUNE7-IGNAY-5UATGI","limit_price":66581.5,"order_qty":1.50192021,"timestamp":"2024-05-19T18:55:25.967603045Z"},
             {"order_id":"ORCUC4-UGIUC-MT5KBA","limit_price":66583.7,"order_qty":0.87745184,"timestamp":"2024-05-19T18:55:18.938264721Z"}
-        ]
+        ],
+        "timestamp":"2024-05-19T18:59:44.999999999Z"
     }]}"#.to_string();
 
         let expected_snapshot = WssMessage::Channel(ChannelMessage::L3(SingleResponse {
@@ -741,6 +742,7 @@ mod tests {
                     },
                 ],
                 checksum: 1361442827,
+                timestamp: "2024-05-19T18:59:44.999999999Z".to_string(),
             }),
         }));
 
@@ -758,6 +760,7 @@ mod tests {
         "type":"update",
         "data":[{
             "checksum":2143854316,
+            "timestamp":"2024-05-19T18:59:44.999999999Z",
             "symbol":"BTC/USD",
             "bids":[
                 {
@@ -801,6 +804,7 @@ mod tests {
                 ],
                 asks: vec![],
                 checksum: 2143854316,
+                timestamp: "2024-05-19T18:59:44.999999999Z".to_string(),
             }),
         }));
 

--- a/src/wss/messages/market_data_messages.rs
+++ b/src/wss/messages/market_data_messages.rs
@@ -168,6 +168,7 @@ pub struct L3Orderbook {
     pub bids: Vec<L3BidAsk>,
     pub asks: Vec<L3BidAsk>,
     pub checksum: u32,
+    pub timestamp: String, // rfc3339
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -176,6 +177,7 @@ pub struct L3OrderbookUpdate {
     pub bids: Vec<L3BidAskUpdate>,
     pub asks: Vec<L3BidAskUpdate>,
     pub checksum: u32,
+    pub timestamp: String, // rfc3339
 }
 
 #[derive(Debug, Deserialize, PartialEq)]


### PR DESCRIPTION
There are several trade types not represented in the direct documentation, as found by https://github.com/Brendan-Blanchard/kraken-async-rs/issues/10.

The CSV documentation mentions these here: https://support.kraken.com/hc/en-us/articles/360001184886-How-to-interpret-Trades-history-fields

With the addition of the `timestamp` parameter in the L3 types, this should bring the library up to date with everything to the May 7, 2025 changelog entries (most changes are documentation or for Spot Websockets V1)
- https://docs.kraken.com/api/docs/change-log/